### PR TITLE
Implement WC3 native mocks for standalone testing of SyncStream and Serializer

### DIFF
--- a/TestLib_standalone.lua
+++ b/TestLib_standalone.lua
@@ -28,7 +28,10 @@ Debug = {
         error(table.concat({...}, " "), 2)
     end,
     beginFile = function() end,
-    endFile = function() end
+    endFile = function() end,
+    traceback = function()
+        return debug.traceback("", 2)
+    end
 }
 
 LogWrite = function(...)
@@ -39,22 +42,310 @@ LogWriteNoFlush = function(...)
     print(...)
 end
 
--- Mock OnInit - just store functions but don't execute them
-OnInit = {
-    map = function(func) end,
-    global = function(func) end,
-    trig = function(func) end,
-    final = function(func) end
+-- Mock OnInit - store and execute functions when needed
+local onInitCallbacks = {
+    map = {},
+    global = {},
+    trig = {},
+    final = {}
 }
 
--- Mock WC3 natives needed for library loading
-FourCC = function(code) return 0 end
-Preload = function(data) end
-PreloadGenClear = function() end
-PreloadGenEnd = function(filename) end
-Preloader = function(filename) end
-BlzGetAbilityTooltip = function(abilityId, level) return '!@#$, empty data' end
-BlzSetAbilityTooltip = function(abilityId, tooltip, level) end
+OnInit = {
+    map = function(func) table.insert(onInitCallbacks.map, func) end,
+    global = function(func) table.insert(onInitCallbacks.global, func) end,
+    trig = function(func) table.insert(onInitCallbacks.trig, func) end,
+    final = function(func) table.insert(onInitCallbacks.final, func) end
+}
+
+local function executeOnInitCallbacks()
+    for _, func in ipairs(onInitCallbacks.map) do func() end
+    for _, func in ipairs(onInitCallbacks.global) do func() end
+    for _, func in ipairs(onInitCallbacks.trig) do func() end
+    for _, func in ipairs(onInitCallbacks.final) do func() end
+end
+
+-- Mock WC3 constants
+bj_MAX_PLAYER_SLOTS = 24
+
+-- Mock Player objects
+local playerObjects = {}
+local function createPlayerObject(id)
+    return {_id = id, _type = "player"}
+end
+
+for i = 0, bj_MAX_PLAYER_SLOTS - 1 do
+    playerObjects[i] = createPlayerObject(i)
+end
+
+Player = function(id)
+    -- Always return the same player object for a given ID
+    if not playerObjects[id] then
+        playerObjects[id] = createPlayerObject(id)
+    end
+    return playerObjects[id]
+end
+
+GetPlayerId = function(player)
+    return player._id
+end
+
+GetLocalPlayer = function()
+    -- Always return the same Player(0) object
+    return Player(0)
+end
+
+GetPlayerName = function(player)
+    return "Player " .. player._id
+end
+
+-- Mock coroutine/timer system
+local activeTimers = {}
+local currentTime = 0
+
+CreateTimer = function()
+    local timer = {
+        _callback = nil,
+        _timeout = 0,
+        _periodic = false,
+        _active = false,
+        _nextTrigger = 0
+    }
+    return timer
+end
+
+TimerStart = function(timer, timeout, periodic, callback)
+    timer._callback = callback
+    timer._timeout = timeout
+    timer._periodic = periodic
+    timer._active = true
+    timer._nextTrigger = currentTime + timeout
+    -- Add timer to active timers list if not already there
+    local found = false
+    for _, t in ipairs(activeTimers) do
+        if t == timer then
+            found = true
+            break
+        end
+    end
+    if not found then
+        table.insert(activeTimers, timer)
+    end
+end
+
+PauseTimer = function(timer)
+    timer._active = false
+end
+
+DestroyTimer = function(timer)
+    for i, t in ipairs(activeTimers) do
+        if t == timer then
+            table.remove(activeTimers, i)
+            break
+        end
+    end
+end
+
+-- Mock trigger system
+local triggerIdCounter = 0
+local activeTriggers = {}
+local syncEventHandlers = {} -- Maps prefix -> list of {trigger, player}
+local currentTriggerData = {
+    player = nil,
+    syncData = nil
+}
+
+CreateTrigger = function()
+    triggerIdCounter = triggerIdCounter + 1
+    local trigger = {
+        _id = triggerIdCounter,
+        _actions = {},
+        _enabled = true
+    }
+    activeTriggers[trigger._id] = trigger
+    return trigger
+end
+
+TriggerAddAction = function(trigger, action)
+    table.insert(trigger._actions, action)
+end
+
+BlzTriggerRegisterPlayerSyncEvent = function(trigger, player, prefix, fromServer)
+    if not syncEventHandlers[prefix] then
+        syncEventHandlers[prefix] = {}
+    end
+    table.insert(syncEventHandlers[prefix], {trigger = trigger, player = player})
+end
+
+GetTriggerPlayer = function()
+    return currentTriggerData.player
+end
+
+BlzGetTriggerSyncData = function()
+    return currentTriggerData.syncData
+end
+
+DisableTrigger = function(trigger)
+    trigger._enabled = false
+end
+
+DestroyTrigger = function(trigger)
+    activeTriggers[trigger._id] = nil
+end
+
+-- Mock sync data system
+BlzSendSyncData = function(prefix, data)
+    -- In WC3, BlzSendSyncData sends data from the local player to all clients
+    -- The trigger fires on all clients with GetTriggerPlayer() returning the sender
+    local sender = GetLocalPlayer()
+    
+    -- Immediately trigger all registered handlers for this prefix
+    local handlers = syncEventHandlers[prefix]
+    if handlers then
+        for _, handler in ipairs(handlers) do
+            -- Only trigger if this handler is registered for the sender player
+            if handler.trigger._enabled and handler.player == sender then
+                -- Set the current trigger context
+                currentTriggerData.player = sender
+                currentTriggerData.syncData = data
+                
+                -- Execute all actions registered to this trigger
+                for _, action in ipairs(handler.trigger._actions) do
+                    action()
+                end
+                
+                -- Clear the context
+                currentTriggerData.player = nil
+                currentTriggerData.syncData = nil
+            end
+        end
+    end
+    return true
+end
+
+-- Mock TriggerSleepAction with coroutine support
+local runningCoroutines = {}
+
+TriggerSleepAction = function(duration)
+    local co = coroutine.running()
+    
+    -- Always advance time and process timers
+    currentTime = currentTime + duration
+    
+    -- Process any timers that should fire
+    for _, timer in ipairs(activeTimers) do
+        while timer._active and timer._nextTrigger <= currentTime do
+            if timer._callback then
+                timer._callback()
+            end
+            if timer._periodic then
+                timer._nextTrigger = timer._nextTrigger + timer._timeout
+            else
+                timer._active = false
+                break
+            end
+        end
+    end
+    
+    if not co then
+        -- Not in a coroutine, just return
+        return
+    end
+    
+    -- In a coroutine, yield (time has already been advanced)
+    table.insert(runningCoroutines, {co = co, resumeTime = currentTime})
+    coroutine.yield()
+end
+
+-- Helper function to process timers and coroutines (no longer used since TriggerSleepAction handles it)
+local function processTimersAndCoroutines()
+    -- Process coroutines
+    local i = 1
+    while i <= #runningCoroutines do
+        local coData = runningCoroutines[i]
+        if coData.resumeTime <= currentTime then
+            table.remove(runningCoroutines, i)
+            local success, err = coroutine.resume(coData.co)
+            if not success then
+                error("Coroutine error: " .. tostring(err))
+            end
+        else
+            i = i + 1
+        end
+    end
+end
+
+-- Mock file system for FileIO
+local fileSystem = {}
+
+Preload = function(data)
+    -- Store data for the current file being written
+    if not fileSystem._currentFile then
+        fileSystem._currentFile = {}
+    end
+    table.insert(fileSystem._currentFile, data)
+end
+
+PreloadGenClear = function()
+    fileSystem._currentFile = {}
+end
+
+PreloadGenEnd = function(filename)
+    if fileSystem._currentFile then
+        fileSystem[filename] = table.concat(fileSystem._currentFile)
+        fileSystem._currentFile = nil
+    end
+end
+
+Preloader = function(filename)
+    local content = fileSystem[filename]
+    if content then
+        -- The WC3 Preloader format wraps the content in a function call
+        -- We need to extract the executable Lua code from the format
+        -- Format: ")\nendfunction\n//!beginusercode\n<LUA CODE>\n//!endusercode\nfunction a takes nothing returns nothing\n//"
+        
+        local startMarker = "//!beginusercode\n"
+        local endMarker = "\n//!endusercode"
+        local startPos = content:find(startMarker, 1, true)
+        local endPos = content:find(endMarker, 1, true)
+        
+        if startPos and endPos then
+            local luaCode = content:sub(startPos + #startMarker, endPos - 1)
+            
+            -- Execute the Lua code with access to BlzSetAbilityTooltip and ANdc
+            -- ANdc is the FourCC code used by FileIO for the load ability
+            local env = {
+                BlzSetAbilityTooltip = BlzSetAbilityTooltip,
+                ANdc = FourCC('ANdc'),  -- Provide the ability ID
+                table = table,
+                string = string,
+                math = math,
+                print = print
+            }
+            setmetatable(env, {__index = _G})
+            local func, err = load(luaCode, filename, "t", env)
+            if func then
+                local success, execErr = pcall(func)
+                if not success then
+                    print("Error executing Preloader content:", execErr)
+                end
+            else
+                print("Error loading Preloader content:", err)
+            end
+        end
+    end
+end
+
+local abilityTooltips = {}
+
+BlzGetAbilityTooltip = function(abilityId, level)
+    return abilityTooltips[abilityId] or '!@#$, empty data'
+end
+
+BlzSetAbilityTooltip = function(abilityId, tooltip, level)
+    abilityTooltips[abilityId] = tooltip
+end
+
+FourCC = function(code) return code end
 
 -- Load libraries using dofile (no gsub stripping needed - Debug is mocked)
 print("=== Loading StringEscape.lua ===")
@@ -63,11 +354,17 @@ dofile(scriptDir .. "lua/MyLibs/StringEscape.lua")
 print("=== Loading FileIO.lua ===")
 dofile(scriptDir .. "lua/MyLibs/FileIO.lua")
 
+print("=== Loading SyncStream.lua ===")
+dofile(scriptDir .. "lua/MyLibs/SyncStream.lua")
+
 print("=== Loading Serializer.lua ===")
 dofile(scriptDir .. "lua/MyLibs/Serializer.lua")
 
 print("=== Loading TestLib.lua ===")
 dofile(scriptDir .. "lua/TestLib.lua")
+
+print("=== Executing OnInit callbacks ===")
+executeOnInitCallbacks()
 
 print("=== Libraries loaded successfully ===\n")
 
@@ -105,6 +402,54 @@ local origTable = {
     { largeNumbers = { 0x40000000, 0x7FFFFFFF } },  -- Large numbers (2^30, 2^31-1) - removed negative numbers
 }
 
+-- Helper function to run async tests in coroutines
+local function runAsyncTest(testName, testFunc)
+    print("\n--- Running " .. testName .. " ---")
+    local co = coroutine.create(testFunc)
+    local success, err = coroutine.resume(co)
+    if not success then
+        error("Test " .. testName .. " failed: " .. tostring(err))
+    end
+    
+    -- Process coroutines until the test coroutine is done
+    -- Note: TriggerSleepAction now handles time advancement and timer processing
+    local maxIterations = 10000
+    local iterations = 0
+    while coroutine.status(co) ~= "dead" and iterations < maxIterations do
+        -- Resume any coroutines that are ready
+        local i = 1
+        while i <= #runningCoroutines do
+            local coData = runningCoroutines[i]
+            if coData.resumeTime <= currentTime then
+                table.remove(runningCoroutines, i)
+                local success, err = coroutine.resume(coData.co)
+                if not success then
+                    error("Coroutine error: " .. tostring(err))
+                end
+            else
+                i = i + 1
+            end
+        end
+        
+        -- If no coroutines are ready, we're stuck
+        if coroutine.status(co) ~= "dead" and #runningCoroutines == 0 then
+            error("Test " .. testName .. " is stuck with no coroutines waiting")
+        end
+        
+        iterations = iterations + 1
+    end
+    
+    if iterations >= maxIterations then
+        error("Test " .. testName .. " timed out after " .. maxIterations .. " iterations")
+    end
+    
+    -- Clean up any remaining coroutines after the test completes
+    -- Note: Do NOT clear activeTimers as they may be needed by subsequent tests (e.g., SyncStream timer)
+    runningCoroutines = {}
+    
+    print("--- " .. testName .. " completed ---")
+end
+
 -- Run the standalone-compatible tests
 print("\n============================================================")
 print("RUNNING STANDALONE TESTS FOR WC3UTILS")
@@ -114,6 +459,10 @@ test_AddEscaping()
 test_RemoveEscaping()
 test_roundtrip()
 test_dumpLoad(origTable)
+
+print("\n--- Running async tests ---")
+runAsyncTest("test_sync", test_sync)
+runAsyncTest("test_saveLoad", test_saveLoad)
 
 print("\n============================================================")
 print("ALL TESTS PASSED!")

--- a/lua/TestLib.lua
+++ b/lua/TestLib.lua
@@ -262,6 +262,7 @@ function test_saveLoad()
     LogWrite("saveFile saved")
 
     -- Doing GetLocalPlayer here to make sure the syncing really work even when running in LAN with 2 players on the same computer
+    local callbackExecuted = false
     local error = Serializer.loadFile(Player(0),"Savegames\\TestMap\\test_save_load_" .. GetPlayerId((GetLocalPlayer())) .. ".txt", function(loadedVars)
         LogWrite("in callback")
         if loadedVars == nil then
@@ -270,9 +271,19 @@ function test_saveLoad()
         end
         Debug.assert(deepCompare(origTable, loadedVars), "loaded table doesn't match the original table")
         LogWrite("EndFunc test ended! validation done")
-
+        callbackExecuted = true
     end)
     LogWrite("loaded returned:", error)
+    
+    -- Wait for the callback to be executed
+    local count = 0
+    while not callbackExecuted and count < 100 do
+        TriggerSleepAction(0.1)
+        count = count + 1
+    end
+    if not callbackExecuted then
+        Debug.throwError("test_saveLoad timed out waiting for callback")
+    end
 end
 
 --- Syncs all the data in input. Must be called from a yieldable coroutine


### PR DESCRIPTION
# Implement WC3 native mocks for standalone SyncStream and Serializer testing

## Summary
This PR implements comprehensive WC3 native function mocks in `TestLib_standalone.lua` to enable `test_sync` and `test_saveLoad` to run in a standalone Lua environment without requiring the WC3 game runtime. The implementation includes:

- **Player object system** with reference equality to ensure `Player(0) == Player(0)` returns true
- **Timer system** with periodic callback support and proper time advancement
- **Trigger system** with sync event handlers for `BlzSendSyncData`/`BlzTriggerRegisterPlayerSyncEvent`
- **TriggerSleepAction** with coroutine support for async operations
- **File system mocks** using in-memory storage for FileIO operations
- **Preloader format parsing** to extract and execute WC3 file format
- **Async test runner** with coroutine management and timer processing
- **OnInit callback execution** to properly initialize SyncStream

Additionally, `test_saveLoad` in `TestLib.lua` was modified to wait for the async callback to complete before returning.

## Review & Testing Checklist for Human

- [ ] **Verify test_sync passes completely** - Run `lua TestLib_standalone.lua` and confirm all sync operations (empty sync, single char, large data, all chars) pass
- [ ] **Check test_saveLoad behavior** - The callback executes successfully, but fails on deepCompare due to 32-bit vs 64-bit Lua number representation (-1 vs 4294967295). Verify this is acceptable or needs fixing
- [ ] **Test in actual WC3 environment** - The mocks are designed to replicate WC3 behavior, but should be tested in-game to ensure compatibility
- [ ] **Verify timer persistence** - activeTimers are intentionally NOT cleared between tests (only runningCoroutines) to allow SyncStream's periodic timer to persist. Confirm this doesn't cause test interference
- [ ] **Review Player object reference equality fix** - Ensure `GetLocalPlayer()` always returning the same Player(0) instance doesn't break other functionality

### Test Plan
```bash
# Run standalone tests
lua TestLib_standalone.lua

# Expected output:
# - All escaping tests pass ✓
# - test_sync passes completely ✓
# - test_saveLoad callback executes ✓ (but may fail on deepCompare due to -1 serialization)
```

### Notes
- **Known Issue**: test_saveLoad fails on the final deepCompare because -1 serializes as 4294967295 (0xFFFFFFFF) in 64-bit Lua vs 32-bit WC3 Lua. This is documented in the original code with the comment "only works for 32 bit lua". The mocks work correctly - this is a data compatibility issue, not a mock issue.
- **Timer Management**: The SyncStream periodic timer must persist across tests, so activeTimers is NOT cleared between test runs (only runningCoroutines are cleared)
- **Coroutine Handling**: TriggerSleepAction advances time and processes timers before yielding, ensuring timers fire at the correct times

---

**Session**: https://app.devin.ai/sessions/7373f3b4eb5c48a7a73013a87c93b096  
**Requested by**: tom mottes (tom.mottes@gmail.com) / @Tomotz